### PR TITLE
Schema: Updated description object to be separate fields

### DIFF
--- a/schemas/schema-0.0.0.json
+++ b/schemas/schema-0.0.0.json
@@ -4,225 +4,309 @@
     "description": "A metadata standard for software repositories of CMS",
     "type": "object",
     "properties": {
-      "items": {
-          "name": {
-              "type": "string",
-              "description": "Name of the project or software"
-          },
-          "softwareDescription": {
-              "type": "object",
-              "properties": {
-                  "en": {
-                      "type": "object",
-                      "description": "Language of description (English)",
-                      "properties": {
-                          "shortDescription": {
-                              "type": "string", 
-                              "description": "A short description of the project. It should be a single line containing a single sentence. Maximum 150 characters are allowed.",
-                              "maxLength": 150
-                          },
-                          "longDescription": {
-                              "type": "string", 
-                              "description": "Provide longer description of the software, between 150 and 10000 chars. It is meant to provide an overview of the capabilities of the software for a potential user.",
-                              "minLength": 100
-                          }
-                      }
-                  },
-                  "required": ["shortDescription", "longDescription"]
-              },
-              "required": ["en"]
-          },
-          "status": {
-              "type": "string",
-              "enum": ["Ideation", "Development", "Alpha", "Beta", "Release Candidate", "Production", "Archival"],
-              "description": "Development status of the project"
-          },
-          "permissions": {
-              "type": "object",
-              "description": "An object containing description of the usage/restrictions regarding the release",
-              "properties": {
-                  "license": {
-                      "type": "array",
-                      "items": {
-                          "type": "object",
-                          "properties": {
-                              "url": {
-                                  "type": "string",
-                                  "format": "uri",
-                                  "description": "The URL of the release license"
-                              },
-                              "name": {
-                                  "type": "string",
-                                  "enum": ["CC0-1.0", "Apache-2.0", "MIT", "MPL-2.0", "GPL-2.0-only", "GPL-3.0-only", "GPL-3.0-or-later", "LGPL-2.1-only", "LGPL-3.0-only", "BSD-2-Clause", "BSD-3-Clause", "EPL-2.0", "Other", "None"],
-                                  "description": "An abbreviation for the name of the license"
-                              }
-                          },
-                          "required": ["url", "name"]
-                      }
-                  },
-                  "usageType": {
-                      "type": "string",
-                      "description": "A list of enumerated values which describes the usage permissions for the release: (1) openSource: Open source; (2) governmentWideReuse: Government-wide reuse; (3) exemptByLaw: The sharing of the source code is restricted by law or regulation, including—but not limited to—patent or intellectual property law, the Export Asset Regulations, the International Traffic in Arms Regulation, and the Federal laws and regulations governing classified information; (4) exemptByNationalSecurity: The sharing of the source code would create an identifiable risk to the detriment of national security, confidentiality of Government information, or individual privacy; (5) exemptByAgencySystem: The sharing of the source code would create an identifiable risk to the stability, security, or integrity of the agency’s systems or personnel, (6) exemptByAgencyMission: The sharing of the source code would create an identifiable risk to agency mission, programs, or operations; (7) exemptByCIO: The CIO believes it is in the national interest to exempt sharing the source code; (8) exemptByPolicyDate: The release was created prior to the M-16-21 policy (August 8, 2016)",
-                      "enum": [
-                          "openSource",
-                          "governmentWideReuse",
-                          "exemptByLaw",
-                          "exemptByNationalSecurity",
-                          "exemptByAgencySystem",
-                          "exemptByAgencyMission",
-                          "exemptByCIO",
-                          "exemptByPolicyDate"
-                      ],
-                      "additionalProperties": false
-                  },
-                  "exemptionText": {
-                      "type": ["string", "null"],
-                      "description": "If an exemption is listed in the 'usageType' field, this field should include a one- or two- sentence justification for the exemption used."
-                  }
-              },
-              "additionalProperties": false,
-              "required": ["licenses", "usageType"]
-          },
-          "organization": {
-              "type": "string",
-              "description": "Organization responsible for the project",
-              "enum": ["Centers for Medicare & Medicaid Services"]
-          },
-          "vcs": {
-              "type": "string",
-              "description": "Version control system used",
-              "enum": ["git", "hg", "svn", "rcs", "bzr"]
-          },
-          "laborHours": {
-              "type": "number",
-              "description": "Labor hours invested in the project"
-          },
-          "platforms": {
-              "type": "array",
-              "description": "Platforms supported by the project",
-              "items": {
-                  "type": "string",
-                  "enum": ["web", "windows", "mac", "linux", "ios", "android", "other"]
-              }
-          },
-          "categories": {
-              "type": "array",
-              "description": "Categories the project belongs to. Select from: https://yml.publiccode.tools/categories-list.html",
-              "items": {
-                  "type": "string"
-              }
-          },
-          "softwareType": {
-              "type": "string",
-              "description": "Type of software",
-              "enum": ["standalone/mobile", "standalone/iot", "standalone/desktop", "standalone/web", "standalone/backend", "standalone/other", "addon", "library", "configurationFiles"]
-          },
-          "languages": {
-              "type": "array",
-              "description": "Programming languages that make up the codebase",
-              "items": {
-                  "type": "string"
-              }
-          },
-          "maintenance": {
-              "type": "string",
-              "description": "Maintenance status",
-              "enum": ["internal", "contract", "community", "none"]
-          },
-          "date": {
-              "type": "object",
-              "properties": {
-                  "created": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Creation date of the project"
-                  },
-                  "lastModified": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Date when the project was last modified"
-                  },
-                  "metaDataLastUpdated": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Date when metadata was last updated"
-                  }
-              }
-          },
-          "tags": {
-              "type": "array",
-              "description": "Tags associated with the project",
-              "items": {
-                  "type": "string"
-              }
-          },
-          "contact": {
-              "type": "object",
-              "properties": {
-                "email": {
-                  "type": "string",
-                  "format": "email",
-                  "description": "Email address of the point of contact"
+        "items": {
+            "name": {
+                "type": "string",
+                "description": "Name of the project or software"
+            },
+            "description": {
+                "type": "string",
+                "description": "A short description of the project. It should be a single line containing a single sentence. Maximum 150 characters are allowed.",
+                "maxLength": 150
+            },
+            "longDescription": {
+                "type": "string",
+                "description": "Provide longer description of the software, between 150 and 10000 chars. It is meant to provide an overview of the capabilities of the software for a potential user.",
+                "minLength": 150,
+                "maxLength": 10000
+            },
+            "status": {
+                "type": "string",
+                "enum": [
+                    "Ideation",
+                    "Development",
+                    "Alpha",
+                    "Beta",
+                    "Release Candidate",
+                    "Production",
+                    "Archival"
+                ],
+                "description": "Development status of the project"
+            },
+            "permissions": {
+                "type": "object",
+                "description": "An object containing description of the usage/restrictions regarding the release",
+                "properties": {
+                    "license": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "url": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "The URL of the release license"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "enum": [
+                                        "CC0-1.0",
+                                        "Apache-2.0",
+                                        "MIT",
+                                        "MPL-2.0",
+                                        "GPL-2.0-only",
+                                        "GPL-3.0-only",
+                                        "GPL-3.0-or-later",
+                                        "LGPL-2.1-only",
+                                        "LGPL-3.0-only",
+                                        "BSD-2-Clause",
+                                        "BSD-3-Clause",
+                                        "EPL-2.0",
+                                        "Other",
+                                        "None"
+                                    ],
+                                    "description": "An abbreviation for the name of the license"
+                                }
+                            },
+                            "required": [
+                                "url",
+                                "name"
+                            ]
+                        }
+                    },
+                    "usageType": {
+                        "type": "string",
+                        "description": "A list of enumerated values which describes the usage permissions for the release: (1) openSource: Open source; (2) governmentWideReuse: Government-wide reuse; (3) exemptByLaw: The sharing of the source code is restricted by law or regulation, including—but not limited to—patent or intellectual property law, the Export Asset Regulations, the International Traffic in Arms Regulation, and the Federal laws and regulations governing classified information; (4) exemptByNationalSecurity: The sharing of the source code would create an identifiable risk to the detriment of national security, confidentiality of Government information, or individual privacy; (5) exemptByAgencySystem: The sharing of the source code would create an identifiable risk to the stability, security, or integrity of the agency’s systems or personnel, (6) exemptByAgencyMission: The sharing of the source code would create an identifiable risk to agency mission, programs, or operations; (7) exemptByCIO: The CIO believes it is in the national interest to exempt sharing the source code; (8) exemptByPolicyDate: The release was created prior to the M-16-21 policy (August 8, 2016)",
+                        "enum": [
+                            "openSource",
+                            "governmentWideReuse",
+                            "exemptByLaw",
+                            "exemptByNationalSecurity",
+                            "exemptByAgencySystem",
+                            "exemptByAgencyMission",
+                            "exemptByCIO",
+                            "exemptByPolicyDate"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "exemptionText": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "If an exemption is listed in the 'usageType' field, this field should include a one- or two- sentence justification for the exemption used."
+                    }
                 },
-                "name": {
-                  "type": "string",
-                  "description": "Name of the point of contact"
+                "additionalProperties": false,
+                "required": [
+                    "licenses",
+                    "usageType"
+                ]
+            },
+            "organization": {
+                "type": "string",
+                "description": "Organization responsible for the project",
+                "enum": [
+                    "Centers for Medicare & Medicaid Services"
+                ]
+            },
+            "vcs": {
+                "type": "string",
+                "description": "Version control system used",
+                "enum": [
+                    "git",
+                    "hg",
+                    "svn",
+                    "rcs",
+                    "bzr"
+                ]
+            },
+            "laborHours": {
+                "type": "number",
+                "description": "Labor hours invested in the project"
+            },
+            "platforms": {
+                "type": "array",
+                "description": "Platforms supported by the project",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "web",
+                        "windows",
+                        "mac",
+                        "linux",
+                        "ios",
+                        "android",
+                        "other"
+                    ]
                 }
-              }
-          },
-          "localisation": {
-              "type": "boolean",
-              "description": "Indicates if the project supports multiple languages"
-          },
-          "repoType": {
-              "type": "string",
-              "description": "Does the software accept user input?",
-              "enum": []
-          },
-          "userInput": {
-              "type": "boolean",
-              "description": "Does the software accept user input?"
-          },
-          "fismaLevel": {
-              "type": "string",
-              "description": "FISMA security level",
-              "enum": ["Low", "Moderate", "High"]
-          },
-          "group": {
-              "type": "string",
-              "description": "Home Department / Org / Group associated with the project"
-          },
-          "subsetInHealthcare": {
-              "type": "array",
-              "items": {
-                  "type": "string",
-                  "enum": ["Policy", "Operational", "Medicare", "Medicaid"]
-              },
-              "description": "Healthcare-related subset"
-          },
-          "userType": {
-              "type": "array",
-              "items": {
-                  "type": "string",
-                  "enum": ["Providers", "Patients", "Government"]
-              },
-              "description": "Types of users who interact with the software"
-          },
-          "repositoryHost": {
-              "type": "string",
-              "description": "Location where source code is hosted",
-              "enum": ["github.com/CMSgov", "github.com/CMSgov", "github.cms.gov", "CCSQ GitHub"]
-          },
-          "maturityModelTier": {
-              "type": "integer",
-              "enum": [1, 2, 3, 4],
-              "description": "Maturity model tier"
-          }
-      }
+            },
+            "categories": {
+                "type": "array",
+                "description": "Categories the project belongs to. Select from: https://yml.publiccode.tools/categories-list.html",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "softwareType": {
+                "type": "string",
+                "description": "Type of software",
+                "enum": [
+                    "standalone/mobile",
+                    "standalone/iot",
+                    "standalone/desktop",
+                    "standalone/web",
+                    "standalone/backend",
+                    "standalone/other",
+                    "addon",
+                    "library",
+                    "configurationFiles"
+                ]
+            },
+            "languages": {
+                "type": "array",
+                "description": "Programming languages that make up the codebase",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "maintenance": {
+                "type": "string",
+                "description": "Maintenance status",
+                "enum": [
+                    "internal",
+                    "contract",
+                    "community",
+                    "none"
+                ]
+            },
+            "date": {
+                "type": "object",
+                "properties": {
+                    "created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the project"
+                    },
+                    "lastModified": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date when the project was last modified"
+                    },
+                    "metaDataLastUpdated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date when metadata was last updated"
+                    }
+                }
+            },
+            "tags": {
+                "type": "array",
+                "description": "Tags associated with the project",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "contact": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "Email address of the point of contact"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the point of contact"
+                    }
+                }
+            },
+            "localisation": {
+                "type": "boolean",
+                "description": "Indicates if the project supports multiple languages"
+            },
+            "repositoryType": {
+                "type": "string",
+                "description": "Format of repository",
+                "enum": [
+                    "package",
+                    "website",
+                    "standards",
+                    "libraries",
+                    "data",
+                    "application",
+                    "tools",
+                    "APIs"
+                ]
+            },
+            "userInput": {
+                "type": "boolean",
+                "description": "Does the software accept user input?"
+            },
+            "fismaLevel": {
+                "type": "string",
+                "description": "FISMA security level",
+                "enum": [
+                    "Low",
+                    "Moderate",
+                    "High"
+                ]
+            },
+            "group": {
+                "type": "string",
+                "description": "Home Department / Org / Group associated with the project"
+            },
+            "subsetInHealthcare": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "Policy",
+                        "Operational",
+                        "Medicare",
+                        "Medicaid"
+                    ]
+                },
+                "description": "Healthcare-related subset"
+            },
+            "userType": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "Providers",
+                        "Patients",
+                        "Government"
+                    ]
+                },
+                "description": "Types of users who interact with the software"
+            },
+            "repositoryHost": {
+                "type": "string",
+                "description": "Location where source code is hosted",
+                "enum": [
+                    "github.com/CMSgov",
+                    "github.com/CMSgov",
+                    "github.cms.gov",
+                    "CCSQ GitHub"
+                ]
+            },
+            "maturityModelTier": {
+                "type": "integer",
+                "enum": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
+                "description": "Maturity model tier"
+            }
+        }
     },
     "required": [
         "name",
-        "softwareDescription",
+        "description",
+        "longDescription",
         "status",
         "permissions",
         "organization",
@@ -237,7 +321,7 @@
         "tags",
         "contact",
         "localisation",
-        "repoType",
+        "repositoryType",
         "userInput",
         "fismaLevel",
         "group",
@@ -245,5 +329,6 @@
         "userType",
         "repositoryHost",
         "maturityModelTier"
-    ]
-  }  
+    ],
+    "additionalProperties": false
+}

--- a/schemas/schema-0.0.0.json
+++ b/schemas/schema-0.0.0.json
@@ -227,7 +227,7 @@
             },
             "repositoryType": {
                 "type": "string",
-                "description": "Format of repository",
+                "description": "Purpose and functionality of the repository",
                 "enum": [
                     "package",
                     "website",


### PR DESCRIPTION
## Problem
Fixing minor issues that came up with schema:
- `softwareDescription` field does not comply with federal code.json
- `repoType` was incorrect and missing options

## Solution
- Updated description fields to be `description` for short description and `longDescription`
- Updated `repoType` to be `repositoryType` and added options
- Reformatted json

