### PR TITLE
Components: Added date-time and boolean components

### DIFF
--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -35,7 +35,12 @@ function determineType(field) {
 		return "radio";
 	} else if (field.type === "number") {
 		return "number";
+	} else if (field.type === "boolean"){
+		return "select-boolean";
 	} else if (field.type === "string") {
+		if (field.format == "date-time") {
+			return "datetime";
+		}
 		return "textfield";
 	}
 }
@@ -110,6 +115,63 @@ function createComponent(fieldName, fieldObject) {
 				inputType: "checkbox",
 				description: fieldObject["description"]
 			};
+		case "datetime":
+			return {
+				"label": fieldName,
+				"tableView": false,
+				"datePicker": {
+					"disableWeekends": false,
+					"disableWeekdays": false
+				},
+				"enableMinDateInput": false,
+				"enableMaxDateInput": false,
+				"validateWhenHidden": false,
+				"key": fieldName,
+				"type": "datetime",
+				"input": true,
+				"widget": {
+					"type": "calendar",
+					"displayInTimezone": "viewer",
+					"locale": "en",
+					"useLocaleSettings": false,
+					"allowInput": true,
+					"mode": "single",
+					"enableTime": true,
+					"noCalendar": false,
+					"format": "yyyy-MM-dd hh:mm a",
+					"hourIncrement": 1,
+					"minuteIncrement": 1,
+					"time_24hr": false,
+					"minDate": null,
+					"disableWeekends": false,
+					"disableWeekdays": false,
+					"maxDate": null
+				},
+				description: fieldObject["description"]
+			}
+		case "select-boolean":
+			return {
+				"label": fieldName,
+				"widget": "html5",
+				"tableView": true,
+				"data": {
+					"values": [
+						{
+							"label": "True",
+							"value": "true"
+						},
+						{
+							"label": "False",
+							"value": "false"
+						}
+					]
+				},
+				"validateWhenHidden": false,
+				"key": fieldName,
+				"type": "select",
+				"input": true,
+				description: fieldObject["description"]
+			}
 		default:
 			break;
 	}

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -80,6 +80,15 @@
 			"type": "string",
 			"description": "Maintenance status",
 			"enum": ["internal", "contract", "community", "none"]
+		},
+		"lastModified": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date when the project was last modified"
+        },
+		"localisation": {
+			"type": "boolean",
+			"description": "Indicates if the project supports multiple languages"
 		}
 	}
 }

--- a/schemas/template-code.json
+++ b/schemas/template-code.json
@@ -9,5 +9,7 @@
 	"categories": [""],
 	"softwareType": [""],
 	"languages": [""],
-	"maintenance": ""
+	"maintenance": "",
+	"lastModified": "",
+	"localisation": ""
 }


### PR DESCRIPTION
## Problem
To collect information for fields like `lastModified` and`localisation`, etc. we need to implement more components.

## Solution
This PR implements date-time and boolean components. Now the form can create the following components:
- Date-time component (CSS is not working atm due to CDN)
- Single select component for boolean fields with "true" and "false" as options

## Result
Users can generate forms using json schemas that have fields with `type: boolean' and 'type: string' + 'format: date-time'

When users fill out the form and click submit, the `code.json` is generated and downloaded onto their machine.

## Test Plan
1. Start up a HTTP server using python: `python3 -m http.server 8000`
2. Click on `form.html`
3. Here is the form! Right click -> Inspect to open dev tools
4. Fill out the form
5. Click submit and downloads `code.json`. File contents should match what was submitted in the form!

Will create unit tests in a separate PR after OSAB