### PR TITLE
GH Pages: Set up deploy job and publish to GitHub Pages

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,59 +1,85 @@
-name: "run-linting-checks"
+name: "run-checks-and-deploy"
 on:
   push:
     branches:
-      - 'main'
+      - "main"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  resolve-repolinter-json:
-    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
-    with: 
-      url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
-  
-  repolinter-checks:
-    name: Tier 3 Checks
-    needs: resolve-repolinter-json
+  deploy:
     runs-on: ubuntu-latest
-    env:
-      
-      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
-      
     steps:
       - uses: actions/checkout@v4
-      - run: echo $RAW_JSON > repolinter.json
-      - uses: newrelic/repolinter-action@v1
+
+      - uses: actions/setup-node@v4
+
+      - name: Setup GitHub pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          # A path to the JSON/YAML Repolinter ruleset to use, relative to the workflow
-          # working directory (i.e. under `$GITHUB_WORKSPACE`).
-          #
-          # This option is mutually exclusive with config_url. If this option and
-          # config_url are not specified, Repolinter's default ruleset will be used.
-          config_file: 'repolinter.json'
+          path: ./
 
-          # Where repolinter-action should put the linting results. There are two
-          # options available:
-          # * "exit-code": repolinter-action will print the lint output to the console
-          #   and set the exit code to result.passed. This output type is most useful for
-          #   PR status checks.
-          # * "issue": repolinter-action will create a GitHub issue on the current
-          #   repository with the repolinter output and always exit 0. See the README for
-          #   more details on issue outputting behavior. This output type is ideal for
-          #   non-intrusive notification.
-          #
-          # Default: "exit-code"
-          output_type: 'issue'
+      - name: Deploy to GitHub pages
+        uses: actions/deploy-pages@v4
 
-          # The title to use for the issue created by repolinter-action. This title
-          # should indicate the purpose of the issue, as well as that it was created by
-          # a bot.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "[Repolinter] Open Source Policy Issues"
-          output_name: '[Repolinter] Tier 3 Repository Hygiene Issue'
+  # resolve-repolinter-json:
+  #   uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
+  #   with:
+  #     url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
 
-          # The default token is the repolinter token for the DSACMS org
-          # You can change it if needed.
-          
-          token: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
-          
+  # repolinter-checks:
+  #   name: Tier 3 Checks
+  #   needs: resolve-repolinter-json
+  #   runs-on: ubuntu-latest
+  #   env:
+
+  #     RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
+
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - run: echo $RAW_JSON > repolinter.json
+  #     - uses: newrelic/repolinter-action@v1
+  #       with:
+  #         # A path to the JSON/YAML Repolinter ruleset to use, relative to the workflow
+  #         # working directory (i.e. under `$GITHUB_WORKSPACE`).
+  #         #
+  #         # This option is mutually exclusive with config_url. If this option and
+  #         # config_url are not specified, Repolinter's default ruleset will be used.
+  #         config_file: 'repolinter.json'
+
+  #         # Where repolinter-action should put the linting results. There are two
+  #         # options available:
+  #         # * "exit-code": repolinter-action will print the lint output to the console
+  #         #   and set the exit code to result.passed. This output type is most useful for
+  #         #   PR status checks.
+  #         # * "issue": repolinter-action will create a GitHub issue on the current
+  #         #   repository with the repolinter output and always exit 0. See the README for
+  #         #   more details on issue outputting behavior. This output type is ideal for
+  #         #   non-intrusive notification.
+  #         #
+  #         # Default: "exit-code"
+  #         output_type: 'issue'
+
+  #         # The title to use for the issue created by repolinter-action. This title
+  #         # should indicate the purpose of the issue, as well as that it was created by
+  #         # a bot.
+  #         #
+  #         # This option will be ignored if output_type != "issue".
+  #         #
+  #         # Default: "[Repolinter] Open Source Policy Issues"
+  #         output_name: '[Repolinter] Tier 3 Repository Hygiene Issue'
+
+  #         # The default token is the repolinter token for the DSACMS org
+  #         # You can change it if needed.
+
+  #         token: ${{ secrets.REPOLINTER_AUTO_TOKEN }}

--- a/form.html
+++ b/form.html
@@ -27,6 +27,7 @@
 		<script src="https://unpkg.com/formiojs@3.0.0-alpha.13/dist/formio.full.min.js"></script>
 	</head>
 	<body>
+		<div id="form-header"></div>
 		<div id="formio"></div>
 		<script src="js/generateFormComponents.js"></script>
 		<script src="js/formDataToJson.js"></script>

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -115,6 +115,11 @@ function createComponent(fieldName, fieldObject) {
 	}
 }
 
+function createFormHeading(title, description) {
+	const container = document.getElementById('form-header');
+	container.innerHTML = `<h1>${title}</h1>\n<h2>${description}</h2>`;
+}
+
 // Iterates through each json field and creates component array for Form.io
 async function createFormComponents() {
 	let components = [];
@@ -123,6 +128,8 @@ async function createFormComponents() {
 	const filePath = "schemas/schema.json";
 	let jsonData = await retrieveFile(filePath);
 	console.log("JSON Data:", jsonData);
+
+	createFormHeading(jsonData["title"], jsonData["description"]);
 
 	formFields = jsonData["properties"];
 	console.log("form Fields:", formFields);


### PR DESCRIPTION
## Problem
We would like to create and host website for users to fill out the code.json form.

## Solution
Created a job to deploy website using GitHub Pages. Added title and description.

## Result
Once this PR has been merged, form is live through this link: https://dsacms.github.io/codejson-generator/form.html

## Testing
Tested in fork, link is live! https://natalialuzuriaga.github.io/codejson-generator/form.html