### PR TITLE
Add Button and Functionality to Automatically Create a PR adding code.json to Project

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -54,7 +54,7 @@ jobs:
         # Runs Snyk Code (SAST) analysis and uploads result into GitHub.
         # Use || true to not fail the pipeline
       - name: Snyk Code test
-        run: snyk code test --sarif > snyk-code.sarif # || true
+        run: snyk code test -d --sarif > snyk-code.sarif # || true
 
         # Runs Snyk Open Source (SCA) analysis and uploads result to Snyk.
       - name: Snyk Open Source monitor

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
         	<textarea class="form-control" rows="10" id="json-result" readonly></textarea>
 			<button type="button" class="btn btn-outline" href="#" onclick="copyToClipboard(event)">Copy</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="downloadFile(event)">Download</button>
+			<button type="button" class="btn btn-outline" href="#" onclick="createProjectPR(event)">Create Pull Request</button>
 		</div>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
 		<!-- <script src="https://cdn.form.io/uswds/uswds.min.js"></script> -->
 		<!-- <script src="https://cdn.form.io/formiojs/formio.full.js"></script> -->
 		<!-- <script src="https://cdn.form.io/js/formio.embed.js"></script> -->
-		<meta charset="utf-8">
 
 		<link rel="icon" type="image/x-icon" href="favicon.ico">
 		

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 		<!-- <script src="https://cdn.form.io/uswds/uswds.min.js"></script> -->
 		<!-- <script src="https://cdn.form.io/formiojs/formio.full.js"></script> -->
 		<!-- <script src="https://cdn.form.io/js/formio.embed.js"></script> -->
-
+		<meta charset="utf-8">
 		<!-- Uses bootstrap for now -->
 		<link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'>
 		<link rel="stylesheet" href="css/styles.css">

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -95,7 +95,7 @@ async function copyToClipboard(event){
 	document.execCommand("copy")
 }
 
-const NEW_BRANCH = 'code-json-branch';
+const NEW_BRANCH = 'code-json-branch' + Math.random().toString(36).substring(2, 10);
 
 function getOrgAndRepoArgsGitHub(url)
 {

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -78,6 +78,10 @@ async function createCodeJson(data) {
 	delete data.submit;
 	const codeJson = await populateCodeJson(data);
 
+	window.gh_api_key = data['gh_api_key']
+	console.log("TEST")
+	console.log(window.gh_api_key)
+
 	const jsonString = JSON.stringify(codeJson, null, 2);
 	document.getElementById("json-result").value = jsonString;
 }
@@ -96,8 +100,19 @@ async function createProjectPR(event){
 	event.preventDefault();
 
 	var textArea = document.getElementById("json-result");
-    var codeJSONObj = textArea.value.parse()
-	console.log(codeJSONObj)
+    var codeJSONObj = JSON.parse(textArea.value)
+	
+	if('gh_api_key' in window)
+	{
+		var apiKey = window.gh_api_key
+		console.log(apiKey)
+	}
+	else
+	{
+		console.error("No API key found!")
+		alert("No Api Key in submitted data!")
+	}
+	//console.log(codeJSONObj)
 }
 
 // Triggers local file download

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -159,6 +159,7 @@ async function createBranchOnProject(projectURL, token)
 		else
 		{
 			console.error('Error creating new branch: ', newBranchData);
+			alert("Failed to create branch on project! Error code: ", newBranchResponse.status, ". Please check API Key permissions and try again.")
 			return false;
 		}
 	}
@@ -190,7 +191,7 @@ async function addFileToBranch(projectURL, token, codeJSONObj)
 			body: JSON.stringify({
 				message: "Add codejson to project",
 				committer: {
-					name: "CodeJSON formsite",
+					name: "codejson-generator form site",
 					email: "opensource@cms.hhs.gov"
 				},
 				content: encodedContent,
@@ -209,6 +210,7 @@ async function addFileToBranch(projectURL, token, codeJSONObj)
 	else
 	{
 		console.error('Error adding file: ', data);
+		alert("Failed to add file on project! Error code: ", response.status, ". Please check API Key permissions and try again.")
 		return false;
 	}
 }
@@ -227,7 +229,7 @@ async function createPR(projectURL, token)
 			},
 			body: JSON.stringify({
 				title: "Add code.json to Project",
-				body: "Add generated code.json file to project. Code.json was generated via a form.io form site.",
+				body: "Add generated code.json file to project. Code.json was generated via codejson-generator form site.",
 				head: NEW_BRANCH,
 				base: 'main',
 
@@ -245,6 +247,7 @@ async function createPR(projectURL, token)
 	else
 	{
 		console.error("Error creating PR!: ", data);
+		alert("Failed to create PR on project! Error code: ", response.status, ". Please check API Key permissions and try again.")
 		return false;
 	}
 }
@@ -279,18 +282,22 @@ async function createProjectPR(event){
 					}
 				}
 			}
+			else
+			{
+				console.error("Could not create branch on requested repository with the requested API key!")
+			}
 		}
 		else
 		{
 			console.error("No URL found!");
-			alert("No URL given for project!");
+			alert("No URL given for project! Please provide project URL in repositoryURL text box");
 		}
 		
 	}
 	else
 	{
 		console.error("No API key found!");
-		alert("No Api Key in submitted data!");
+		alert("No API Key in submitted data! Please provide an API key");
 	}
 	//console.log(codeJSONObj)
 }

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -159,7 +159,7 @@ async function createBranchOnProject(projectURL, token)
 		else
 		{
 			console.error('Error creating new branch: ', newBranchData);
-			alert("Failed to create branch on project! Error code: ", newBranchResponse.status, ". Please check API Key permissions and try again.")
+			alert("Failed to create branch on project! Error code: " + newBranchResponse.status + ". Please check API Key permissions and try again.")
 			return false;
 		}
 	}
@@ -210,7 +210,7 @@ async function addFileToBranch(projectURL, token, codeJSONObj)
 	else
 	{
 		console.error('Error adding file: ', data);
-		alert("Failed to add file on project! Error code: ", response.status, ". Please check API Key permissions and try again.")
+		alert("Failed to add file on project! Error code: " + response.status + ". Please check API Key permissions and try again.")
 		return false;
 	}
 }
@@ -247,7 +247,7 @@ async function createPR(projectURL, token)
 	else
 	{
 		console.error("Error creating PR!: ", data);
-		alert("Failed to create PR on project! Error code: ", response.status, ". Please check API Key permissions and try again.")
+		alert("Failed to create PR on project! Error code: " + response.status + ". Please check API Key permissions and try again.")
 		return false;
 	}
 }

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -91,6 +91,15 @@ async function copyToClipboard(event){
 	document.execCommand("copy")
 }
 
+// Creates PR on requested project
+async function createProjectPR(event){
+	event.preventDefault();
+
+	var textArea = document.getElementById("json-result");
+    var codeJSONObj = textArea.value.parse()
+	console.log(codeJSONObj)
+}
+
 // Triggers local file download
 async function downloadFile(event) {
 	event.preventDefault();

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -95,22 +95,194 @@ async function copyToClipboard(event){
 	document.execCommand("copy")
 }
 
+const NEW_BRANCH = 'code-json-branch';
+
+function getOrgAndRepoArgsGitHub(url)
+{
+	const pattern = /https:\/\/github\.com\/([^\/]+)\/([^\/]+)/;
+  	const match = url.match(pattern);
+
+	if(match)
+	{
+		const owner = match[1];
+		const repo = match[2];
+		return {owner,repo};
+	}
+	else
+	{
+		throw new Error('Invalid URL!');
+	}
+}
+
+
+async function createBranchOnProject(projectURL, token) 
+{
+	const {owner, repo} = getOrgAndRepoArgsGitHub(projectURL);
+
+	const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/refs/heads/main}`,
+		{
+			method: 'GET',
+			headers: {
+				'Authorization': 'token '.concat(token),
+			},
+		}
+	);
+
+	const data = await response.json();
+
+	if (response.ok)
+	{
+		const sha = data.object.sha;
+		
+		const createBranchApiUrl = `https://api.github.com/repos/${owner}/${repo}/git/refs`;
+
+		// Create the new branch from the base branch
+		const newBranchResponse = await fetch(createBranchApiUrl, {
+			method: 'POST',
+			headers: {
+			  'Content-Type': 'application/json',
+			  'Authorization': `token ${token}`,
+			},
+			body: JSON.stringify({
+			  ref: `refs/heads/${NEW_BRANCH}`, // Name of the new branch
+			  sha: sha, // SHA of the base branch (main)
+			}),
+		});
+
+		const newBranchData = await newBranchResponse.json();
+
+		if ( newBranchResponse.ok )
+		{
+			console.log('New branch created successfully: ', newBranchData);
+			return true;
+		}
+		else
+		{
+			console.error('Error creating new branch: ', newBranchData);
+			return false;
+		}
+	}
+	else
+	{
+		console.error('Error fetching base branch info:', data);
+		return false;
+	}
+}
+
+
+async function addFileToBranch(projectURL, token, codeJSONObj)
+{
+	const {owner, repo} = getOrgAndRepoArgsGitHub(projectURL);
+	const FILE_PATH = 'code.json'
+	const createFileApiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${FILE_PATH}`;
+	const encodedContent = Buffer.from(codeJSONObj).toString('base64');
+
+	const response = await fetch(createFileApiUrl, 
+		{
+			method: 'PUT',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': 'token'.concat(token),
+			},
+			body: JSON.stringify({
+				message: "Add codejson to project",
+				content: encodedContent,
+				branch: NEW_BRANCH,
+			}),
+		}
+	);
+
+	const data = await response.json()
+
+	if ( response.ok )
+	{
+		console.log('File added successfully: ', data);
+		return true;
+	}
+	else
+	{
+		console.error('Error adding file: ', data);
+		return false;
+	}
+}
+
+async function createPR(projectURL, token)
+{
+	const {owner, repo} = getOrgAndRepoArgsGitHub(projectURL);
+	const createPrApiUrl = `https://api.github.com/repos/${owner}/${repo}/pulls`;
+	const response = await fetch(createPrApiUrl, 
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': 'token '.concat(token),
+			},
+			body: JSON.stringify({
+				title: "Add code.json to Project",
+				body: "Add generated code.json file to project. Code.json was generated via a form.io form site.",
+				head: NEW_BRANCH,
+				base: 'main',
+
+			}),
+		}
+	);
+
+	const data = await response.json();
+
+	if (response.ok)
+	{
+		console.log('Pull request created successfully: ', data);
+		return true;
+	}
+	else
+	{
+		console.error("Error creating PR!: ", data);
+		return false;
+	}
+}
+
 // Creates PR on requested project
 async function createProjectPR(event){
 	event.preventDefault();
 
-	var textArea = document.getElementById("json-result");
-    var codeJSONObj = JSON.parse(textArea.value)
+	var textArea = document.getElementById("json-result");//Step 1
+	var codeJSONObj = JSON.parse(textArea.value)
 	
 	if('gh_api_key' in window)
 	{
-		var apiKey = window.gh_api_key
-		console.log(apiKey)
+		var apiKey = window.gh_api_key;
+		
+		if ('repositoryURL' in codeJSONObj)
+		{
+			var prCreated = false;
+			//Step 1
+			const branchCreated = await createBranchOnProject(codeJSONObj.repositoryURL,apiKey);
+			if (branchCreated)
+			{
+				const fileAdded = await addFileToBranch(codeJSONObj.repositoryURL, apiKey, textArea.value);
+
+				if (fileAdded)
+				{
+					prCreated = await createPR(codeJSONObj.repositoryURL, apiKey);
+					if(prCreated)
+					{
+						console.log("PR successfully created!");
+						alert("PR has been created!");
+					}
+				}
+			}
+		}
+		else
+		{
+			console.error("No URL found!");
+			alert("No URL given for project!");
+		}
+		
 	}
 	else
 	{
-		console.error("No API key found!")
-		alert("No Api Key in submitted data!")
+		console.error("No API key found!");
+		alert("No Api Key in submitted data!");
 	}
 	//console.log(codeJSONObj)
 }

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -166,6 +166,7 @@ async function createBranchOnProject(projectURL, token)
 	else
 	{
 		console.error('Error fetching base branch info:', data);
+		alert('Error fetching base branch info:', data);
 		return false;
 	}
 }
@@ -284,7 +285,8 @@ async function createProjectPR(event){
 			}
 			else
 			{
-				console.error("Could not create branch on requested repository with the requested API key!")
+				console.error("Could not create branch on requested repository with the requested API key!");
+				alert("Could not create branch on requested repository with the requested API key!");
 			}
 		}
 		else

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -119,7 +119,7 @@ async function createBranchOnProject(projectURL, token)
 {
 	const {owner, repo} = getOrgAndRepoArgsGitHub(projectURL);
 
-	const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/refs/heads/main}`,
+	const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/refs/heads/main`,
 		{
 			method: 'GET',
 			headers: {
@@ -175,7 +175,8 @@ async function addFileToBranch(projectURL, token, codeJSONObj)
 	const {owner, repo} = getOrgAndRepoArgsGitHub(projectURL);
 	const FILE_PATH = 'code.json'
 	const createFileApiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${FILE_PATH}`;
-	const encodedContent = Buffer.from(codeJSONObj).toString('base64');
+	const encodedContent = btoa(codeJSONObj);
+	console.log("Content: ", encodedContent);
 
 	const response = await fetch(createFileApiUrl, 
 		{

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -177,16 +177,22 @@ async function addFileToBranch(projectURL, token, codeJSONObj)
 	const createFileApiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${FILE_PATH}`;
 	const encodedContent = btoa(codeJSONObj);
 	console.log("Content: ", encodedContent);
+	console.log("Branch: ", NEW_BRANCH);
 
 	const response = await fetch(createFileApiUrl, 
 		{
 			method: 'PUT',
 			headers: {
-				'Content-Type': 'application/json',
-				'Authorization': 'token'.concat(token),
+				'Accept': 'application/vnd.github+json',
+				'Authorization': 'Bearer '.concat(token),
+				'X-GitHub-Api-Version': "2022-11-28"
 			},
 			body: JSON.stringify({
 				message: "Add codejson to project",
+				committer: {
+					name: "CodeJSON formsite",
+					email: "opensource@cms.hhs.gov"
+				},
 				content: encodedContent,
 				branch: NEW_BRANCH,
 			}),
@@ -217,6 +223,7 @@ async function createPR(projectURL, token)
 			headers: {
 				'Content-Type': 'application/json',
 				'Authorization': 'token '.concat(token),
+				'X-GitHub-Api-Version': "2022-11-28"
 			},
 			body: JSON.stringify({
 				title: "Add code.json to Project",

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -323,3 +323,4 @@ async function downloadFile(event) {
 window.createCodeJson = createCodeJson;
 window.copyToClipboard = copyToClipboard;
 window.downloadFile = downloadFile;
+window.createProjectPR = createProjectPR;

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -303,7 +303,11 @@ async function createFormComponents() {
 		"tableView": true,
 		"key": "gh_api_key",
 		"type": "textfield",
-		"input": true
+		"input": true,
+		"description": "Generate a Github API Key from here: https://github.com/settings/tokens/new .\n\
+			The token should have these permissions: \n\
+			- Contents: read &write \n- Workflows: read & write\
+			- Pull requests: read & write"
 	});
 
 	// Add submit button to form

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -296,6 +296,24 @@ async function createFormComponents() {
 
 	components = createAllComponents(jsonData);
 
+	components.push({
+		"label": "GitHub API Key (optional)",
+		"disableSortingAndFiltering": false,
+		"tableView": true,
+		"key": "textField",
+		"type": "textfield",
+		"input": true
+	});
+
+	components.push({
+		"label": "Git URL (optional)",
+		"disableSortingAndFiltering": false,
+		"tableView": true,
+		"key": "textField",
+		"type": "textfield",
+		"input": true
+	});
+
 	// Add submit button to form
 	components.push({
 		type: "button",
@@ -305,6 +323,24 @@ async function createFormComponents() {
 		input: true,
 		tableView: false,
 	});
+
+	
+
+
+	// Add Create PR button to form
+	// Add submit button to form
+	/*
+	components.push({
+		type: "button",
+		label: "Generate code.json metadata and push to Repository",
+		key: "submit",
+		disableOnInvalid: false,
+		input: true,
+		tableView: false,
+	});
+	*/
+
+	
 
 	console.log(components);
 

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -302,7 +302,7 @@ async function createFormComponents() {
 		"disableSortingAndFiltering": false,
 		"tableView": true,
 		"key": "gh_api_key",
-		"type": "textfield",
+		"type": "password",
 		"input": true,
 		"description": "Generate a Github API Key from here: https://github.com/settings/tokens/new .\n\
 			The token should have these permissions: \n\

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -306,7 +306,7 @@ async function createFormComponents() {
 		"input": true,
 		"description": "Generate a Github API Key from here: https://github.com/settings/tokens/new .\n\
 			The token should have these permissions: \n\
-			- Contents: read &write \n- Workflows: read & write\
+			- Contents: read & write \n- Workflows: read & write\
 			- Pull requests: read & write"
 	});
 

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -305,15 +305,6 @@ async function createFormComponents() {
 		"input": true
 	});
 
-	components.push({
-		"label": "Git URL (optional)",
-		"disableSortingAndFiltering": false,
-		"tableView": true,
-		"key": "textField",
-		"type": "textfield",
-		"input": true
-	});
-
 	// Add submit button to form
 	components.push({
 		type: "button",

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -300,7 +300,7 @@ async function createFormComponents() {
 		"label": "GitHub API Key (optional)",
 		"disableSortingAndFiltering": false,
 		"tableView": true,
-		"key": "textField",
+		"key": "gh_api_key",
 		"type": "textfield",
 		"input": true
 	});
@@ -314,22 +314,6 @@ async function createFormComponents() {
 		input: true,
 		tableView: false,
 	});
-
-	
-
-
-	// Add Create PR button to form
-	// Add submit button to form
-	/*
-	components.push({
-		type: "button",
-		label: "Generate code.json metadata and push to Repository",
-		key: "submit",
-		disableOnInvalid: false,
-		input: true,
-		tableView: false,
-	});
-	*/
 
 	
 

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -296,6 +296,7 @@ async function createFormComponents() {
 
 	components = createAllComponents(jsonData);
 
+	//Form text box to input GitHub API Key
 	components.push({
 		"label": "GitHub API Key (optional)",
 		"disableSortingAndFiltering": false,


### PR DESCRIPTION
## Add Button and Functionality to Automatically Create a PR adding code.json to Project

## Problem

Currently, the user has to manually add the generated code.json text to the project either with a direct commit or by PR to the desired project.

## Solution

Use the GitHub API to add the file via REST requests using Javascript fetch logic. 

## Result

Summary

* Add field to input a GitHub API key.
* Add button to create a PR on the project once the code.json has been generated.
* Add method to extract owner and repo from the GitHub url given.
* Add method to create a new branch on the desired project in GitHub. 
* Add method to create a new file (the code.json file) on the new branch created once it is created
* Add method to create a new PR that merges the new branch into 'main'
* Add new method createProjectPR that calls all the previous methods using the generated code.json and tells the user if it succeeded or not.
* Add onclick property to new button that activates createProjectPR to create a functional button

## Test Plan

This is tricky to test tbh. I will probably create my own test repo to test all of this to make sure that it is ready for merge.
