### PR TITLE
Refactor-draft-to-remove-bootstrap

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,7 +1,54 @@
 body {
-    margin: 20px;
+    font-family: "Source Sans Pro", "Helvetica Neue", Arial, Helvetica, sans-serif;
+    line-height: 1.42857143;
+    color: #333;
 }
 
-textarea {
-    margin-bottom: 10px;
+#form-header {
+    margin-bottom: 20px;
+}
+
+#output {
+    margin-top: 20px;
+}
+
+.usa-textarea,
+#json-result {
+    display: block;
+    width: 100%;
+    height: auto;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.42857143;
+    color: #555;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+
+.usa-button {
+    display: inline-block;
+    margin-bottom: 0;
+    font-weight: 400;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    touch-action: manipulation;
+    cursor: pointer;
+    border: 1px solid transparent;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.42857143;
+    border-radius: 4px;
+    user-select: none;
+}
+
+label {
+    display: inline-block;
+    max-width: 100%;
+    margin-bottom: 5px;
+    font-weight: 600;
 }

--- a/index.html
+++ b/index.html
@@ -1,25 +1,25 @@
 <html>
 	<head>
-		<!-- USWDS not working -->
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<!-- <meta name="viewport" content="width=device-width, initial-scale=1"> -->
 		<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"> -->
-		<!-- <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"> -->
-		<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.2/css/uswds.min.css"> -->
 		<!-- <link rel="stylesheet" href="https://cdn.form.io/formiojs/formio.form.min.css"> -->
 		<!-- <link rel="stylesheet" href="https://cdn.form.io/uswds/uswds.min.css"> -->
-		<!-- <link rel="stylesheet" href="https://unpkg.com/formiojs@3.0.0-alpha.13/dist/formio.full.min.css"> -->
-		<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.2/js/uswds.min.js"></script> -->
-		<!-- <script src="https://cdn.form.io/formiojs/formio.form.min.js"></script> -->
-		<!-- <script src="https://cdn.form.io/uswds/uswds.min.js"></script> -->
-		<!-- <script src="https://cdn.form.io/formiojs/formio.full.js"></script> -->
-		<!-- <script src="https://cdn.form.io/js/formio.embed.js"></script> -->
-
-		<!-- Uses bootstrap for now -->
-		<link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'>
+		<!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/formiojs@4.21.6/dist/formio.full.min.css"> -->
+		<!-- <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"> -->
+		<!-- <link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'> -->
+		<!-- <script src="https://cdn.form.io/uswds/uswds.min.js" defer></script> -->
+		<!-- <script src="https://cdn.form.io/formiojs/formio.form.min.js" defer></script> -->
+		<!-- <script src="https://cdn.form.io/formiojs/formio.full.js" defer></script> -->
+		<!-- <script src="https://cdn.form.io/js/formio.embed.js" defer></script> -->
+		
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/3.7.0/css/uswds.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/3.7.0/fonts/fonts.css">
+		<link rel="stylesheet" href="https://unpkg.com/formiojs@4.21.6/dist/formio.full.min.css">
 		<link rel="stylesheet" href="css/styles.css">
-
-		<!-- Working Form.io CDN -->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/uswds/3.7.0/js/uswds.min.js" defer></script>
 		<script src="https://unpkg.com/formiojs@4.21.6/dist/formio.full.min.js"></script>
-		<link href="https://cdn.jsdelivr.net/npm/formiojs@4.21.6/dist/formio.full.min.css" rel="stylesheet">
 
 		<!-- Render the form -->
 		<script src="js/generateFormComponents.js"></script>
@@ -52,11 +52,11 @@
 	<body>
 		<div id="form-header"></div>
 		<div id="formio"></div>
-		<div id="output">
+		<div id="output" class="margin-top-3">
 			<label for="json-result">Your JSON Metadata </label>
-        	<textarea class="form-control" rows="10" id="json-result" readonly></textarea>
-			<button type="button" class="btn btn-outline" href="#" onclick="copyToClipboard(event)">Copy</button>
-			<button type="button" class="btn btn-outline" href="#" onclick="downloadFile(event)">Download</button>
+        	<textarea class="form-control usa-textarea" rows="10" id="json-result" readonly></textarea>
+			<button type="button" class="btn btn-outline usa-button" href="#" onclick="copyToClipboard(event)">Copy</button>
+			<button type="button" class="btn btn-outline usa-button" href="#" onclick="downloadFile(event)">Download</button>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
### Initial Problem:
- form.html contains the form. USWDS does not work at the moment (see: https://github.com/formio/uswds/issues/260) so we are temporarily using bootstrap.
- When not using bootstrap the Formio is not defined error shows and the form in its entirety is not rendered.
- USWDS object is undefined.

### Initial Fix:
- Bootstrap removed / commented out
- Stylesheets and Scripts LNs: 5-15 deleted/commented out. These were causing overrides and did not allow the form to load properly.
- Changed stylesheet and script both to `formiojs@4.21.6` so both would match
- Defer was added to script LN: 21, this prevents the script from loading until the page is parsed and allows the form to load properly

### New Problem
- Bootstrap and USWDS have different design philosophies.
- Bootstrap: Uses a generic design framework for broad compatibility
- USWDS: Is a specific design frame work
- Deleting Bootstrap allows USWDS to override the initial CSS of the project.

Question:
- How do we proceed?
  - A. We can stick with USWDS and add classes where needed 
  - B. Continue to use Bootstrap