### PR TITLE
Schema: Added new projectURL field and tier 0 for maturityModelTier field

### DIFF
--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -116,6 +116,11 @@
                 "format": "uri",
                 "description": "The URL of the public release repository for open source repositories. This field is not required for repositories that are only available as government-wide reuse or are closed (pursuant to one of the exemptions)."
             },
+            "projectURL": {
+                "type": "string",
+                "format": "uri",
+                "description": "URL to landing page, demo or production instance of project"
+            },
             "repositoryHost": {
                 "type": "string",
                 "description": "Location where source code is hosted",
@@ -129,7 +134,10 @@
             },
             "repositoryVisibility": {
                 "type": "string",
-                "enum": ["public", "private"],
+                "enum": [
+                    "public",
+                    "private"
+                ],
                 "description": "Visibility of repository"
             },
             "vcs": {
@@ -151,11 +159,11 @@
                 "type": "object",
                 "description": "Measures frequency of code reuse in various forms. (e.g. forks, downloads, clones)",
                 "properties": {
-                    "forks": { 
-                        "type": "integer" 
+                    "forks": {
+                        "type": "integer"
                     },
-                    "clones": { 
-                        "type": "integer" 
+                    "clones": {
+                        "type": "integer"
                     }
                 },
                 "additionalProperties": true
@@ -307,14 +315,14 @@
             "projects": {
                 "type": "array",
                 "description": "Project(s) that is associated or related to the repository, if any (e.g. Bluebutton, MPSM)",
-                "items": { 
+                "items": {
                     "type": "string"
                 }
             },
             "systems": {
                 "type": "array",
                 "description": "CMS systems that the repository interfaces with or depends on, if any (e.g. IDR, PECOS)",
-                "items": { 
+                "items": {
                     "type": "string"
                 }
             },
@@ -350,6 +358,7 @@
             "maturityModelTier": {
                 "type": "integer",
                 "enum": [
+                    0,
                     1,
                     2,
                     3,


### PR DESCRIPTION
## Problem
We would like to add a new `projectURL` field to collect information on production instance or landing page URL for project. 
Additionally, Tier 0 is missing from `maturityModelTier` field

## Solution
- Add a new `projectURL` field to schema. It is optional and a CMS-specific field. 
- Added Tier 0 as option to `maturityModelTier` field