### PR TITLE
Schema: Updated repositoryURL field and value if private

### DIFF
--- a/js/autoGenerateFields.js
+++ b/js/autoGenerateFields.js
@@ -180,7 +180,13 @@ function preFillFields(repoData, languages) {
 
         // Updating URL
         if (repoData.html_url) {
-            form.getComponent('repositoryURL').setValue(repoData.html_url)
+            if (repoData.private) {
+                // Private repositories must have "private" as their repositoryURL value
+                form.getComponent('repositoryURL').setValue("private")
+            }
+            else {
+                form.getComponent('repositoryURL').setValue(repoData.html_url)
+            }
         }
 
         // Updating forks
@@ -277,11 +283,11 @@ function preFillFields(repoData, languages) {
         }
 
         // fields to potentially automate
-            // clones, but this is only tracked for every 14 days 
-            // status, by checking if its public, we can assume its production and check if its archival 
-            // laborHours, by running a script? this might be harder since we need SCC
-            // maturityModel, we could check to see if certain files / sections live within a repo and make a guess like that
-            // usageType, by assuming that if its public = openSource and if private = governmnetWideReuse
+        // clones, but this is only tracked for every 14 days 
+        // status, by checking if its public, we can assume its production and check if its archival 
+        // laborHours, by running a script? this might be harder since we need SCC
+        // maturityModel, we could check to see if certain files / sections live within a repo and make a guess like that
+        // usageType, by assuming that if its public = openSource and if private = governmnetWideReuse
 
         notificationSystem.success("Repository data loaded successfully!")
 

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -114,7 +114,7 @@
             "repositoryURL": {
                 "type": "string",
                 "format": "uri",
-                "description": "The URL of the public release repository for open source repositories. This field is not required for repositories that are only available as government-wide reuse or are closed (pursuant to one of the exemptions)."
+                "description": "The URL of the public release repository for open source repositories. This field is not required for repositories that are only available as government-wide reuse or are closed (pursuant to one of the exemptions). It can be listed as 'private' for repositories that are closed."
             },
             "projectURL": {
                 "type": "string",


### PR DESCRIPTION
# Schema: Updated repositoryURL field and value if private

## Problem
Needed extra guidance for what to put down for repositoryURL if the repository is private

## Solution
- Added new flavor text with the addition: It can be listed as "private" for repositories that are closed
- Updated automateGenerateFields to reflect this. (The form for right now only supports public repositories but this will be here once we are able to support private/closed)