### PR TITLE
Form: Uses Latest Schema + Guidance Improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,11 +281,13 @@
 	</div>
 
 	<!-- Form header -->
-	<div id="form-subheader">
+	<div class="form-subheader">
 		<div class="step-header">
 			<div class="step-number">3</div>
 			<h2>Complete the entire form to generate the code.json file</h2>
 		</div>
+		<p class="usa-heading margin-top-neg-05 margin-bottom-2"><em>A red asterisk (<span style="color:red">*</span>)
+				indicates a required field</em></p>
 	</div>
 
 	<div id="formio"></div>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html lang="en-US">
 <meta charset="UTF-8">
+<meta name="description" content="Form to generate a code.json file containing repository metadata">
 
 <head>
 	<title>code.json metadata</title>
@@ -24,6 +25,7 @@
 	<script type="text/javascript">
 		createFormComponents()
 			.then((components) => {
+				console.log(components, 'components');
 				Formio.use(uswds);
 				Formio.createForm(document.getElementById("formio"), {
 					display: "form",

--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
 	<script type="text/javascript">
 		createFormComponents()
 			.then((components) => {
-				console.log(components, 'components');
 				Formio.use(uswds);
 				Formio.createForm(document.getElementById("formio"), {
 					display: "form",

--- a/js/autoGenerateFields.js
+++ b/js/autoGenerateFields.js
@@ -279,10 +279,9 @@ async function preFillFields(repoData, languages) {
             feedbackComp.setValue(issuesUrl)
         }
 
-        // Update upstream 
-
-        if (form.getComponent('upstream') && repoData.html_url) {
-            const upstreamComp = form.getComponent('upstream');
+        // Update SBOM
+        if (form.getComponent('SBOM') && repoData.html_url) {
+            const upstreamComp = form.getComponent('SBOM');
             const urlParts = repoData.html_url.split('/')
 
             if (urlParts.length >= 2) {

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -290,7 +290,6 @@ async function createProjectPR(event) {
 		console.error("No API key found!");
 		alert("No API Key in submitted data! Please provide an API key");
 	}
-	//console.log(codeJSONObj)
 }
 
 // Triggers local file download

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -66,23 +66,24 @@ function determineType(field) {
 }
 
 // Creates Form.io component based on json field type
-function createComponent(fieldName, fieldObject, requiredArray) {
+function createComponent(fieldName, fieldObject, requiredArray, prefix) {
 	const componentType = determineType(fieldObject);
 	console.log(componentType, "type determined");
 	const validate = determineValidation(fieldName, fieldObject, requiredArray);
+	const label = !validate.required && !prefix ? fieldName + " (optional)" : fieldName;
 	switch (componentType) {
 		case "textfield":
 			return {
 				type: "textfield",
 				key: fieldName,
-				label: fieldName,
+				label: label,
 				input: true,
 				description: fieldObject["description"],
 				validate
 			};
 		case "tags":
 			return {
-				label: fieldName,
+				label: label,
 				tableView: false,
 				storeas: "array",
 				validateWhenHidden: false,
@@ -94,7 +95,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 			};
 		case "number":
 			return {
-				label: fieldName,
+				label: label,
 				applyMaskOn: "change",
 				mask: false,
 				tableView: false,
@@ -111,7 +112,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 			};
 		case "integer":
 			return {
-				label: fieldName,
+				label: label,
 				applyMaskOn: "change",
 				mask: false,
 				tableView: false,
@@ -131,7 +132,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 			var options = transformArrayToOptions(fieldObject.enum);
 			console.log("checking options here:", options);
 			return {
-				label: fieldName,
+				label: label,
 				optionsLabelPosition: "right",
 				inline: false,
 				tableView: false,
@@ -147,7 +148,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 			var options = transformArrayToOptions(fieldObject.items.enum);
 			console.log("checking options here:", options);
 			return {
-				label: fieldName,
+				label: label,
 				optionsLabelPosition: "right",
 				tableView: false,
 				values: options,
@@ -161,7 +162,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 			};
 		case "datetime":
 			return {
-				label: fieldName,
+				label: label,
 				tableView: false,
 				datePicker: {
 					disableWeekends: false,
@@ -189,7 +190,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 			};
 		case "select-boolean":
 			return {
-				label: fieldName,
+				label: label,
 				widget: "html5",
 				tableView: true,
 				data: {
@@ -213,7 +214,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 			};
 		case "container":
 			return {
-				label: fieldName,
+				label: label,
 				hideLabel: false,
 				tableView: false,
 				validateWhenHidden: false,
@@ -226,7 +227,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 			};
 		case "datagrid":
 			return {
-				label: fieldName,
+				label: label,
 				reorder: false,
 				addAnotherPosition: "bottom",
 				layoutFixed: false,
@@ -246,7 +247,7 @@ function createComponent(fieldName, fieldObject, requiredArray) {
 		case "content":
 			return {
 				html: `<p class="margin-top-neg-3 margin-bottom-4 text-base-dark">${fieldObject["content"]}</p>`,
-				label: fieldName,
+				label: label,
 				customClass: fieldObject["className"],
 				refreshOnChange: false,
 				key: fieldName,
@@ -287,7 +288,7 @@ function createAllComponents(schema, prefix = "") {
 			console.log("key at play:", key);
 			const fullKey = prefix ? `${prefix}.${key}` : key;
 
-			let fieldComponent = createComponent(key, value, requiredArray);
+			let fieldComponent = createComponent(key, value, requiredArray, prefix);
 
 			if (fieldComponent.type === "container") {
 				fieldComponent.components = createAllComponents(value, fullKey);

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -68,7 +68,6 @@ function determineType(field) {
 // Creates Form.io component based on json field type
 function createComponent(fieldName, fieldObject, requiredArray, prefix) {
 	const componentType = determineType(fieldObject);
-	console.log(componentType, "type determined");
 	const validate = determineValidation(fieldName, fieldObject, requiredArray);
 	const label = !validate.required && !prefix ? fieldName + " (optional)" : fieldName;
 	switch (componentType) {
@@ -363,10 +362,6 @@ async function createFormComponents() {
 		input: true,
 		tableView: false,
 	});
-
-
-
-	console.log(components);
 
 	return components;
 }

--- a/js/generateFormComponents.js
+++ b/js/generateFormComponents.js
@@ -261,11 +261,20 @@ function createComponent(fieldName, fieldObject, requiredArray, prefix) {
 }
 
 // Adds heading containing schema information
-function createFormHeading(title, description) {
+function createFormHeading(agency) {
+	const agencyTitle = (agency === "gov") ? agency.charAt(0).toUpperCase() + agency.slice(1) : agency.toUpperCase();
+	const agencyDescription = (agency !== "gov") ? agencyTitle : agency;
+
 	const container = document.getElementById('form-header');
 	container.innerHTML = `
-	<h1>${title}</h1>\n
-	<h2>${description}</h2>\n
+	<h1>Welcome to ${agencyTitle} Code.json Generator!</h1>\n
+	<h2>code.json generator is a web form designed to help ${agencyDescription} teams create a code.json file containing project metadata in compliance with the SHARE IT Act. 
+	Visit the <a
+    				class="usa-link usa-link--external"
+    				rel="noreferrer"
+    				target="_blank"
+    				href="https://dsacms.github.io/share-it-act-lp/">
+					SHARE IT Act Landing Page</a> for more information.</h2>\n
 	<h3>Complete the form below to create a code.json file for your project:</h3>\n
 	`;
 }
@@ -327,7 +336,7 @@ async function createFormComponents() {
 	const jsonData = await retrieveFile(filePath);
 	console.log("JSON Data:", jsonData);
 
-	createFormHeading(jsonData["title"], jsonData["description"]);
+	createFormHeading(page);
 
 	components = createAllComponents(jsonData);
 

--- a/schemas/cms/schema.json
+++ b/schemas/cms/schema.json
@@ -1,12 +1,17 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "CMS Code.json Metadata",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://dsacms.github.io/code-json-schema.json",
+    "title": "CMS code.json metadata",
     "description": "A metadata standard for software repositories of CMS",
     "type": "object",
     "properties": {
         "name": {
             "type": "string",
             "description": "Name of the project or software"
+        },
+        "version": {
+            "type": "string",
+            "description": "The version for this release. For example, '1.0.0'."
         },
         "description": {
             "type": "string",
@@ -70,7 +75,8 @@
                         "required": [
                             "name",
                             "URL"
-                        ]
+                        ],
+                        "additionalProperties": false
                     }
                 },
                 "usageType": {
@@ -95,8 +101,7 @@
                             "exemptByPolicyDate"
                         ]
                     },
-                    "description": "A list of enumerated values which describes the usage permissions for the release: (1) openSource: Open source; (2) governmentWideReuse: Government-wide reuse; (3) exemptByNationalSecurity: The source code is primarily for use in national security system as defined in section 11103 of title 40, USC; (4) exemptByNationalIntelligence: The source code is developed by an agency or part of an agency that is an element of the intelligence community, as defined in section 3(4) of the National Security Act of 1947; (5) exemptByFOIA: The source code is exempt under the Freedom of Information Act; (6) exemptByEAR: The source code is exempt under the Export Administration Regulations; (7) exemptByITAR: The source code is exempt under the the International Traffic in Arms Regulations; (8) exemptByTSA: The source code is exempt under the regulations of the Transportation Security Administration relating to the protection of Sensitive Security Information; (9) exemptByClassifiedInformation: The source code is exempt under the Federal laws and regulations governing the sharing of classified information not covered by exemptByNationalSecurity, exemptByNationalIntelligence, exemptbyFOIA, exemptByEAR, exemptByITAR, and exemptByTSA; (10) exemptByPrivacyRisk: The sharing or public accessibility of the source code would create an identifiable risk to the privacy of an individual; (11) exemptByIPRestriction: The sharing of the source code is limited by patent or intellectual property restrictions; (12) exemptByAgencySystem: The sharing of the source code would create an identifiable risk to the stability, security, or integrity of the agency’s systems or personnel; (13) exemptByAgencyMission: The sharing of the source code would create an identifiable risk to agency mission, programs, or operations;  (14) exemptByCIO: The CIO believes it is in the national interest to exempt sharing the source code;  (15) exemptByPolicyDate: The release was created prior to the M-16-21 policy (August 8, 2016)",
-                    "additionalProperties": false
+                    "description": "A list of enumerated values which describes the usage permissions for the release: (1) openSource: Open source; (2) governmentWideReuse: Government-wide reuse; (3) exemptByNationalSecurity: The source code is primarily for use in national security system as defined in section 11103 of title 40, USC; (4) exemptByNationalIntelligence: The source code is developed by an agency or part of an agency that is an element of the intelligence community, as defined in section 3(4) of the National Security Act of 1947; (5) exemptByFOIA: The source code is exempt under the Freedom of Information Act; (6) exemptByEAR: The source code is exempt under the Export Administration Regulations; (7) exemptByITAR: The source code is exempt under the the International Traffic in Arms Regulations; (8) exemptByTSA: The source code is exempt under the regulations of the Transportation Security Administration relating to the protection of Sensitive Security Information; (9) exemptByClassifiedInformation: The source code is exempt under the Federal laws and regulations governing the sharing of classified information not covered by exemptByNationalSecurity, exemptByNationalIntelligence, exemptbyFOIA, exemptByEAR, exemptByITAR, and exemptByTSA; (10) exemptByPrivacyRisk: The sharing or public accessibility of the source code would create an identifiable risk to the privacy of an individual; (11) exemptByIPRestriction: The sharing of the source code is limited by patent or intellectual property restrictions; (12) exemptByAgencySystem: The sharing of the source code would create an identifiable risk to the stability, security, or integrity of the agency's systems or personnel; (13) exemptByAgencyMission: The sharing of the source code would create an identifiable risk to agency mission, programs, or operations;  (14) exemptByCIO: The CIO believes it is in the national interest to exempt sharing the source code;  (15) exemptByPolicyDate: The release was created prior to the M-16-21 policy (August 8, 2016)"
                 },
                 "exemptionText": {
                     "type": [
@@ -124,11 +129,6 @@
             "format": "uri",
             "description": "The URL of the public release repository for open source repositories. This field is not required for repositories that are only available as government-wide reuse or are closed (pursuant to one of the exemptions). It can be listed as 'private' for repositories that are closed."
         },
-        "projectURL": {
-            "type": "string",
-            "format": "uri",
-            "description": "URL to landing page, demo, or production instance of project"
-        },
         "repositoryHost": {
             "type": "string",
             "description": "Location where source code is hosted",
@@ -149,6 +149,25 @@
             ],
             "description": "Visibility of repository"
         },
+        "homepageURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the public release homepage."
+        },
+        "downloadURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where a distribution of the release can be found."
+        },
+        "disclaimerURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where disclaimer language regarding the release can be found."
+        },
+        "disclaimerText": {
+            "type": "string",
+            "description": "Short paragraph that includes disclaimer language to accompany the release."
+        },
         "vcs": {
             "type": "string",
             "description": "Version control system used",
@@ -157,11 +176,13 @@
                 "hg",
                 "svn",
                 "rcs",
-                "bzr"
+                "bzr",
+                "none"
             ]
         },
         "laborHours": {
             "type": "number",
+            "minimum": 0,
             "description": "Labor hours invested in the project. Calculated using COCOMO measured by the SCC tool: https://github.com/boyter/scc?tab=readme-ov-file#cocomo"
         },
         "reuseFrequency": {
@@ -169,10 +190,12 @@
             "description": "Measures frequency of code reuse in various forms. (e.g. forks, downloads, clones)",
             "properties": {
                 "forks": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "clones": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 }
             },
             "additionalProperties": true
@@ -191,14 +214,16 @@
                     "android",
                     "other"
                 ]
-            }
+            },
+            "uniqueItems": true
         },
         "categories": {
             "type": "array",
             "description": "Categories the project belongs to. Select from: https://yml.publiccode.tools/categories-list.html",
             "items": {
                 "type": "string"
-            }
+            },
+            "uniqueItems": true
         },
         "softwareType": {
             "type": "string",
@@ -220,7 +245,8 @@
             "description": "Programming languages that make up the codebase",
             "items": {
                 "type": "string"
-            }
+            },
+            "uniqueItems": true
         },
         "maintenance": {
             "type": "string",
@@ -237,6 +263,71 @@
             "description": "Contract number(s) under which the project was developed",
             "items": {
                 "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "SBOM": {
+            "type": "string",
+            "description": "Link of the upstream repositories and dependencies used, in the form of a Software Bill of Materials/SBOM. If the software does not have a SBOM, enter 'None'. (i.e. Github provides an SBOM: https://github.com/$ORG_NAME/$REPO_NAME/network/dependencies)"
+        },
+        "relatedCode": {
+            "type": "array",
+            "description": "An array of affiliated government repositories that may be a part of the same project. For example,  relatedCode for 'code-gov-front-end' would include 'code-gov-api' and 'code-gov-api-client'.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the code repository, project, library or release."
+                    },
+                    "URL": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The URL where the code repository, project, library or release can be found."
+                    },
+                    "isGovernmentRepo": {
+                        "type": "boolean",
+                        "description": "True or False. Is the code repository owned or managed by a federal agency?"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "reusedCode": {
+            "type": "array",
+            "description": "An array of government source code, libraries, frameworks, APIs, platforms or other software used in this release. For example, US Web Design Standards, cloud.gov, Federalist, Digital Services Playbook, Analytics Reporter.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the software used in this release."
+                    },
+                    "URL": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The URL where the software can be found."
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "partners": {
+            "type": "array",
+            "description": "An array of objects including an acronym for each agency partnering on the release and the contact email at such agency.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The acronym describing the partner agency."
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "The email address for the point of contact at the partner agency."
+                    }
+                },
+                "additionalProperties": false
             }
         },
         "date": {
@@ -258,14 +349,16 @@
                     "format": "date-time",
                     "description": "Date when metadata was last updated"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "tags": {
             "type": "array",
             "description": "Topics and keywords associated with the project to improve search and discoverability",
             "items": {
                 "type": "string"
-            }
+            },
+            "uniqueItems": true
         },
         "contact": {
             "type": "object",
@@ -280,7 +373,8 @@
                     "type": "string",
                     "description": "Name of the point of contact"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "feedbackMechanism": {
             "type": "string",
@@ -331,18 +425,16 @@
             "description": "Project(s) that is associated or related to the repository, if any (e.g. Bluebutton, MPSM)",
             "items": {
                 "type": "string"
-            }
+            },
+            "uniqueItems": true
         },
         "systems": {
             "type": "array",
             "description": "CMS systems that the repository interfaces with or depends on, if any (e.g. IDR, PECOS)",
             "items": {
                 "type": "string"
-            }
-        },
-        "upstream": {
-            "type": "string",
-            "description": "Link of the upstream repositories and dependencies used, in the form of a Software Bill of Materials/SBOM (https://github.com/$ORG_NAME/$REPO_NAME/network/dependencies)"
+            },
+            "uniqueItems": true
         },
         "subsetInHealthcare": {
             "type": "array",
@@ -355,7 +447,8 @@
                     "medicaid"
                 ]
             },
-            "description": "Healthcare-related subset"
+            "description": "Healthcare-related subset",
+            "uniqueItems": true
         },
         "userType": {
             "type": "array",
@@ -367,7 +460,8 @@
                     "government"
                 ]
             },
-            "description": "Types of users who interact with the software"
+            "description": "Types of users who interact with the software",
+            "uniqueItems": true
         },
         "maturityModelTier": {
             "type": "integer",
@@ -400,6 +494,7 @@
         "languages",
         "maintenance",
         "contractNumber",
+        "SBOM",
         "date",
         "tags",
         "contact",

--- a/schemas/gov/schema.json
+++ b/schemas/gov/schema.json
@@ -1,5 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://dsacms.github.io/code-json-schema.json",
     "title": "code.json metadata",
     "description": "A metadata standard for software repositories",
     "type": "object",
@@ -7,6 +8,10 @@
         "name": {
             "type": "string",
             "description": "Name of the project or software"
+        },
+        "version": {
+            "type": "string",
+            "description": "The version for this release. For example, '1.0.0'."
         },
         "description": {
             "type": "string",
@@ -64,7 +69,8 @@
                         "required": [
                             "name",
                             "URL"
-                        ]
+                        ],
+                        "additionalProperties": false
                     }
                 },
                 "usageType": {
@@ -89,8 +95,7 @@
                             "exemptByPolicyDate"
                         ]
                     },
-                    "description": "A list of enumerated values which describes the usage permissions for the release: (1) openSource: Open source; (2) governmentWideReuse: Government-wide reuse; (3) exemptByNationalSecurity: The source code is primarily for use in national security system as defined in section 11103 of title 40, USC; (4) exemptByNationalIntelligence: The source code is developed by an agency or part of an agency that is an element of the intelligence community, as defined in section 3(4) of the National Security Act of 1947; (5) exemptByFOIA: The source code is exempt under the Freedom of Information Act; (6) exemptByEAR: The source code is exempt under the Export Administration Regulations; (7) exemptByITAR: The source code is exempt under the the International Traffic in Arms Regulations; (8) exemptByTSA: The source code is exempt under the regulations of the Transportation Security Administration relating to the protection of Sensitive Security Information; (9) exemptByClassifiedInformation: The source code is exempt under the Federal laws and regulations governing the sharing of classified information not covered by exemptByNationalSecurity, exemptByNationalIntelligence, exemptbyFOIA, exemptByEAR, exemptByITAR, and exemptByTSA; (10) exemptByPrivacyRisk: The sharing or public accessibility of the source code would create an identifiable risk to the privacy of an individual; (11) exemptByIPRestriction: The sharing of the source code is limited by patent or intellectual property restrictions; (12) exemptByAgencySystem: The sharing of the source code would create an identifiable risk to the stability, security, or integrity of the agency’s systems or personnel; (13) exemptByAgencyMission: The sharing of the source code would create an identifiable risk to agency mission, programs, or operations;  (14) exemptByCIO: The CIO believes it is in the national interest to exempt sharing the source code;  (15) exemptByPolicyDate: The release was created prior to the M-16-21 policy (August 8, 2016)",
-                    "additionalProperties": false
+                    "description": "A list of enumerated values which describes the usage permissions for the release: (1) openSource: Open source; (2) governmentWideReuse: Government-wide reuse; (3) exemptByNationalSecurity: The source code is primarily for use in national security system as defined in section 11103 of title 40, USC; (4) exemptByNationalIntelligence: The source code is developed by an agency or part of an agency that is an element of the intelligence community, as defined in section 3(4) of the National Security Act of 1947; (5) exemptByFOIA: The source code is exempt under the Freedom of Information Act; (6) exemptByEAR: The source code is exempt under the Export Administration Regulations; (7) exemptByITAR: The source code is exempt under the the International Traffic in Arms Regulations; (8) exemptByTSA: The source code is exempt under the regulations of the Transportation Security Administration relating to the protection of Sensitive Security Information; (9) exemptByClassifiedInformation: The source code is exempt under the Federal laws and regulations governing the sharing of classified information not covered by exemptByNationalSecurity, exemptByNationalIntelligence, exemptbyFOIA, exemptByEAR, exemptByITAR, and exemptByTSA; (10) exemptByPrivacyRisk: The sharing or public accessibility of the source code would create an identifiable risk to the privacy of an individual; (11) exemptByIPRestriction: The sharing of the source code is limited by patent or intellectual property restrictions; (12) exemptByAgencySystem: The sharing of the source code would create an identifiable risk to the stability, security, or integrity of the agency's systems or personnel; (13) exemptByAgencyMission: The sharing of the source code would create an identifiable risk to agency mission, programs, or operations;  (14) exemptByCIO: The CIO believes it is in the national interest to exempt sharing the source code;  (15) exemptByPolicyDate: The release was created prior to the M-16-21 policy (August 8, 2016)"
                 },
                 "exemptionText": {
                     "type": [
@@ -123,6 +128,25 @@
             ],
             "description": "Visibility of repository"
         },
+        "homepageURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the public release homepage."
+        },
+        "downloadURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where a distribution of the release can be found."
+        },
+        "disclaimerURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where disclaimer language regarding the release can be found."
+        },
+        "disclaimerText": {
+            "type": "string",
+            "description": "Short paragraph that includes disclaimer language to accompany the release."
+        },
         "vcs": {
             "type": "string",
             "description": "Version control system used",
@@ -131,11 +155,13 @@
                 "hg",
                 "svn",
                 "rcs",
-                "bzr"
+                "bzr",
+                "none"
             ]
         },
         "laborHours": {
             "type": "number",
+            "minimum": 0,
             "description": "Labor hours invested in the project. Calculated using COCOMO measured by the SCC tool: https://github.com/boyter/scc?tab=readme-ov-file#cocomo"
         },
         "reuseFrequency": {
@@ -143,10 +169,12 @@
             "description": "Measures frequency of code reuse in various forms. (e.g. forks, downloads, clones)",
             "properties": {
                 "forks": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "clones": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 }
             },
             "additionalProperties": true
@@ -156,7 +184,8 @@
             "description": "Programming languages that make up the codebase",
             "items": {
                 "type": "string"
-            }
+            },
+            "uniqueItems": true
         },
         "maintenance": {
             "type": "string",
@@ -173,6 +202,71 @@
             "description": "Contract number(s) under which the project was developed",
             "items": {
                 "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "SBOM": {
+            "type": "string",
+            "description": "Link of the upstream repositories and dependencies used, in the form of a Software Bill of Materials/SBOM. If the software does not have a SBOM, enter 'None'. (i.e. Github provides an SBOM: https://github.com/$ORG_NAME/$REPO_NAME/network/dependencies)"
+        },
+        "relatedCode": {
+            "type": "array",
+            "description": "An array of affiliated government repositories that may be a part of the same project. For example,  relatedCode for 'code-gov-front-end' would include 'code-gov-api' and 'code-gov-api-client'.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the code repository, project, library or release."
+                    },
+                    "URL": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The URL where the code repository, project, library or release can be found."
+                    },
+                    "isGovernmentRepo": {
+                        "type": "boolean",
+                        "description": "True or False. Is the code repository owned or managed by a federal agency?"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "reusedCode": {
+            "type": "array",
+            "description": "An array of government source code, libraries, frameworks, APIs, platforms or other software used in this release. For example, US Web Design Standards, cloud.gov, Federalist, Digital Services Playbook, Analytics Reporter.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the software used in this release."
+                    },
+                    "URL": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The URL where the software can be found."
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "partners": {
+            "type": "array",
+            "description": "An array of objects including an acronym for each agency partnering on the release and the contact email at such agency.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The acronym describing the partner agency."
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "The email address for the point of contact at the partner agency."
+                    }
+                },
+                "additionalProperties": false
             }
         },
         "date": {
@@ -194,14 +288,16 @@
                     "format": "date-time",
                     "description": "Date when metadata was last updated"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "tags": {
             "type": "array",
             "description": "Topics and keywords associated with the project to improve search and discoverability",
             "items": {
                 "type": "string"
-            }
+            },
+            "uniqueItems": true
         },
         "contact": {
             "type": "object",
@@ -216,7 +312,8 @@
                     "type": "string",
                     "description": "Name of the point of contact"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "feedbackMechanism": {
             "type": "string",
@@ -242,6 +339,7 @@
         "languages",
         "maintenance",
         "contractNumber",
+        "SBOM",
         "date",
         "tags",
         "contact",


### PR DESCRIPTION
## Problem
Currently, the web form does not use the latest v2 Gov and CMS Schema. We also would like to improve the instructions and guidance on required vs optional fields

## Solution
- Update Gov & CMS schema to the latest version: v2.0.0
- Update form instructions with link to SHARE IT Act Landing Page
- Add optional text to optional fields as recommended here: https://designsystem.digital.gov/components/form/
- Add helper text explaining required fields as recommended here: https://designsystem.digital.gov/components/form/
- Update meta tag to include description content

## Test Plan
Works locally `python3 -m http.server 8000 `, successfully generates CMS and Gov code.json